### PR TITLE
Use `removeFromSuperview` to replace `hidden` operation

### DIFF
--- a/LazyScrollView/TMMuiLazyScrollView.h
+++ b/LazyScrollView/TMMuiLazyScrollView.h
@@ -87,7 +87,7 @@
 @property (nonatomic, weak, nullable)   id <TMMuiLazyScrollViewDataSource> dataSource;
 
 // Get Visible Views
-@property (nonatomic, strong, readonly,nonnull) NSMutableSet *visibleItems;
+@property (nonatomic, strong, readonly, nonnull) NSMutableSet *visibleItems;
 
 // reloads everything from scratch and redisplays visible views.
 - (void)reloadData;

--- a/LazyScrollView/TMMuiLazyScrollView.m
+++ b/LazyScrollView/TMMuiLazyScrollView.m
@@ -495,7 +495,7 @@
             //Then recycle the view.
             NSMutableSet *recycledIdentifierSet = [self recycledIdentifierSet:view.reuseIdentifier];
             [recycledIdentifierSet addObject:view];
-            view.hidden = YES;
+            [view removeFromSuperview];
             [recycledItems addObject:view];
         }
         else if (isReload && view.muiID) {
@@ -529,7 +529,6 @@
                 if (viewToShow)
                 {
                     viewToShow.muiID = muiID;
-                    viewToShow.hidden = NO;
                     if (![self.visibleItems containsObject:viewToShow]) {
                         [self.visibleItems addObject:viewToShow];
                     }
@@ -624,7 +623,7 @@
     for (UIView *view in visibles) {
         NSMutableSet *recycledIdentifierSet = [self recycledIdentifierSet:view.reuseIdentifier];
         [recycledIdentifierSet addObject:view];
-        view.hidden = YES;
+        [view removeFromSuperview];
     }
     [_visibleItems removeAllObjects];
     [_recycledIdentifierItemsDic removeAllObjects];


### PR DESCRIPTION
1.
`hidden`为YES的在界面外的视图，若没有重用，则依然在`UIScrollView`的视图层级上。所以在大量cell，且种类很多的情况下，
会造成视图上`hidden`为YES的视图大量存在。
2. `- (UIView *)scrollView:(TMMuiLazyScrollView *)scrollView
itemByMuiID:(NSString *)muiID`方法中，获取到reusable视图后，同样会进行视图层级的调整。
3.
综上，我觉得应该采用`UITableView`、`UICollectionView`类似的复用机制，当视图移出界面时调用`removeFromS
uperView`。