### PR TITLE
fixed bugs and use `hidden` to replace `removeFromSuperview` operation

### DIFF
--- a/LazyScrollView/TMMuiLazyScrollView.m
+++ b/LazyScrollView/TMMuiLazyScrollView.m
@@ -159,7 +159,7 @@
     [_secondSet removeAllObjects],_secondSet = nil;
     _modelsSortedByTop = nil;
     _modelsSortedByBottom = nil;
-
+    
 }
 
 //replace UIScrollDelegate to TMMuiLazyScrollViewDelegate for insert code in scrollDidScroll .
@@ -187,7 +187,7 @@
         self.lastScrollOffset = scrollView.contentOffset;
         [self assembleSubviews];
         [self findViewsInVisibleRect];
-
+        
     }
     if (self.lazyScrollViewDelegate && [self.lazyScrollViewDelegate conformsToProtocol:@protocol(UIScrollViewDelegate)] && [self.lazyScrollViewDelegate respondsToSelector:@selector(scrollViewDidScroll:)])
     {
@@ -469,19 +469,19 @@
 // A simple method to make view that should be shown show in LazyScrollView
 - (void)assembleSubviews
 {
-     CGRect visibleBounds = self.bounds;
-     // Visible area adding buffer to form a area that need to calculate which view should be shown.
-     CGFloat minY = CGRectGetMinY(visibleBounds) - RenderBufferWindow;
-     CGFloat maxY = CGRectGetMaxY(visibleBounds) + RenderBufferWindow;
-     [self assembleSubviewsForReload:NO minY:minY maxY:maxY];
+    CGRect visibleBounds = self.bounds;
+    // Visible area adding buffer to form a area that need to calculate which view should be shown.
+    CGFloat minY = CGRectGetMinY(visibleBounds) - RenderBufferWindow;
+    CGFloat maxY = CGRectGetMaxY(visibleBounds) + RenderBufferWindow;
+    [self assembleSubviewsForReload:NO minY:minY maxY:maxY];
 }
 
 - (void)assembleSubviewsForReload:(BOOL)isReload minY:(CGFloat)minY maxY:(CGFloat)maxY
 {
-  
+    
     NSSet *itemShouldShowSet = [self showingItemIndexSetFrom:minY to:maxY];
     self.muiIDOfVisibleViews = [self showingItemIndexSetFrom:CGRectGetMinY(self.bounds) to:CGRectGetMaxY(self.bounds)];
-
+    
     NSMutableSet  *recycledItems = [[NSMutableSet alloc] init];
     //For recycling . Find which views should not in visible area.
     NSSet *visibles = [self.visibleItems copy];
@@ -495,10 +495,11 @@
             //Then recycle the view.
             NSMutableSet *recycledIdentifierSet = [self recycledIdentifierSet:view.reuseIdentifier];
             [recycledIdentifierSet addObject:view];
-            [view removeFromSuperview];
+            view.hidden = YES;
             [recycledItems addObject:view];
         }
         else if (isReload && view.muiID) {
+            view.hidden = YES;
             [self.shouldReloadItems addObject:view.muiID];
         }
     }
@@ -529,6 +530,7 @@
                 if (viewToShow)
                 {
                     viewToShow.muiID = muiID;
+                    viewToShow.hidden = NO;
                     if (![self.visibleItems containsObject:viewToShow]) {
                         [self.visibleItems addObject:viewToShow];
                     }
@@ -577,7 +579,8 @@
     if (self.currentVisibleItemMuiID) {
         NSSet *visibles = self.visibleItems;
         for (UIView *v in visibles) {
-            if ([v.muiID isEqualToString:self.currentVisibleItemMuiID]) {
+            if ([v.muiID isEqualToString:self.currentVisibleItemMuiID]
+                && [v.reuseIdentifier isEqualToString:identifier]) {
                 view = v;
                 break;
             }
@@ -623,7 +626,8 @@
     for (UIView *view in visibles) {
         NSMutableSet *recycledIdentifierSet = [self recycledIdentifierSet:view.reuseIdentifier];
         [recycledIdentifierSet addObject:view];
-        [view removeFromSuperview];
+        view.hidden = YES;
+        [view performSelectorOnMainThread:@selector(removeFromSuperview) withObject:nil waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
     }
     [_visibleItems removeAllObjects];
     [_recycledIdentifierItemsDic removeAllObjects];


### PR DESCRIPTION
1. 滑动 scroll view 时频繁 remove subview 会极大消耗 CPU 资源，导致界面卡顿。推荐原有做法，只隐藏不删除。
2. 在 reload 时，页面可见区域内的 view 应先隐藏再根据需求重新设置 hidden 属性，否则 scroll view 的 subview 可能会互相重叠（一些本不应再显示的 view 还显示在 scrollview 上）。